### PR TITLE
Refactor(ui): Introduce tabbed interface to WebsiteActions

### DIFF
--- a/packages/ui/src/components/browser/WebsiteActions/DebugTab.tsx
+++ b/packages/ui/src/components/browser/WebsiteActions/DebugTab.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import styles from './WebsiteActions.module.scss'; // Assuming you might reuse some styles
+
+export const DebugTab: React.FC = () => {
+  const [showPingMessage, setShowPingMessage] = useState(false);
+
+  const handlePingClick = () => {
+    setShowPingMessage(true);
+  };
+
+  return (
+    <> {/* Or a new style class */}
+      <button onClick={handlePingClick} className={styles.actions__button}> {/* Assuming button style reuse */}
+        ping
+      </button>
+      {showPingMessage && (
+        <div className={styles.message}> {/* Assuming message style reuse */}
+          Ping Clicked
+        </div>
+      )}
+    </>
+  );
+};

--- a/packages/ui/src/components/browser/WebsiteActions/LegacyTab.tsx
+++ b/packages/ui/src/components/browser/WebsiteActions/LegacyTab.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import cn from 'classnames';
+import styles from './WebsiteActions.module.scss';
+
+type Props = {
+  is_loading?: boolean;
+  has_content: boolean;
+  is_saved: boolean;
+  on_save: () => void;
+  on_remove: () => void;
+};
+
+const LegacyTab: React.FC<Props> = ({
+  is_loading,
+  has_content,
+  is_saved,
+  on_save,
+  on_remove,
+}) => {
+  // JSX content will be pasted here in the next step
+  if (is_loading === undefined) {
+    // Return an empty fragment or a minimal div if necessary, but not with styles.container
+    return <></>;
+  }
+
+  return (
+    <>
+      {!is_loading ? (
+        <>
+          {has_content ? (
+            <div className={styles.actions}>
+              {!is_saved ? (
+                <button
+                  onClick={on_save}
+                  className={cn(
+                    styles.actions__button,
+                    styles['actions__button--save']
+                  )}
+                >
+                  Enable for context
+                </button>
+              ) : (
+                <button
+                  onClick={on_remove}
+                  className={cn(
+                    styles.actions__button,
+                    styles['actions__button--delete']
+                  )}
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          ) : (
+            <p className={styles.message}>
+              No content could be parsed from this tab.
+            </p>
+          )}
+        </>
+      ) : (
+        <p className={styles.message}>Loading...</p>
+      )}
+    </div>
+  );
+};
+
+export default LegacyTab;

--- a/packages/ui/src/components/browser/WebsiteActions/WebsiteActions.module.scss
+++ b/packages/ui/src/components/browser/WebsiteActions/WebsiteActions.module.scss
@@ -40,3 +40,33 @@
   font-size: 14px;
   text-align: center;
 }
+
+.tabNavigation {
+  display: flex;
+  border-bottom: 1px solid #ccc; // Example border
+  margin-bottom: 10px; // Space between tabs and content
+}
+
+.tabButton {
+  padding: 10px 15px;
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+  font-size: 1em; // Match existing font size if applicable
+
+  &:hover {
+    background-color: #f0f0f0; // Example hover effect
+  }
+}
+
+.activeTabButton {
+  font-weight: bold;
+  border-bottom: 2px solid blue; // Example active indicator
+  color: blue; // Example active text color
+}
+
+.tabContent {
+  // Add any specific styling for the content area if needed
+  // For example, padding:
+  // padding: 10px;
+}

--- a/packages/ui/src/components/browser/WebsiteActions/WebsiteActions.tsx
+++ b/packages/ui/src/components/browser/WebsiteActions/WebsiteActions.tsx
@@ -1,57 +1,60 @@
-import React from 'react'
-import styles from './WebsiteActions.module.scss'
-import cn from 'classnames'
+import React, { useState } from 'react';
+import styles from './WebsiteActions.module.scss';
+import cn from 'classnames';
+import { DebugTab } from './DebugTab';
+import { LegacyTab } from './LegacyTab';
 
 type Props = {
-  is_loading?: boolean
-  has_content: boolean
-  is_saved: boolean
-  on_save: () => void
-  on_remove: () => void
-}
+  is_loading?: boolean;
+  has_content: boolean;
+  is_saved: boolean;
+  on_save: () => void;
+  on_remove: () => void;
+};
 
 export const WebsiteActions: React.FC<Props> = (props) => {
-  if (props.is_loading === undefined) {
-    return <div className={styles.container} />
-  }
+  const [activeTab, setActiveTab] = useState<'debug' | 'legacy'>('debug');
+
+  // It's important to handle the loading state for the LegacyTab.
+  // If LegacyTab is active and is_loading is undefined, we might want to show a loading state.
+  // Or, if props.is_loading is undefined only when the component is initializing,
+  // we might not need this check here if LegacyTab handles its own undefined is_loading.
+  // For now, let's assume LegacyTab handles undefined is_loading as per its original implementation.
+  // The prompt suggested: if (props.is_loading === undefined && activeTab === 'legacy')
+  // This means the blank div only shows if legacy tab is active AND is_loading is undefined.
+  // LegacyTab itself has: if (is_loading === undefined) { return <div className={styles.container} />; }
+  // So, this check might be redundant if LegacyTab is already handling it.
+  // Let's rely on LegacyTab to handle its own loading state based on is_loading prop.
 
   return (
     <div className={styles.container}>
-      {!props.is_loading ? (
-        <>
-          {props.has_content ? (
-            <div className={styles.actions}>
-              {!props.is_saved ? (
-                <button
-                  onClick={props.on_save}
-                  className={cn(
-                    styles.actions__button,
-                    styles['actions__button--save']
-                  )}
-                >
-                  Enable for context
-                </button>
-              ) : (
-                <button
-                  onClick={props.on_remove}
-                  className={cn(
-                    styles.actions__button,
-                    styles['actions__button--delete']
-                  )}
-                >
-                  Remove
-                </button>
-              )}
-            </div>
-          ) : (
-            <p className={styles.message}>
-              No content could be parsed from this tab.
-            </p>
-          )}
-        </>
-      ) : (
-        <p className={styles.message}>Loading...</p>
-      )}
+      <div className={styles.tabNavigation}> {/* Define styles.tabNavigation */}
+        <button
+          onClick={() => setActiveTab('debug')}
+          className={cn(styles.tabButton, activeTab === 'debug' ? styles.activeTabButton : '')} // Define these styles
+        >
+          Debug
+        </button>
+        <button
+          onClick={() => setActiveTab('legacy')}
+          className={cn(styles.tabButton, activeTab === 'legacy' ? styles.activeTabButton : '')} // Define these styles
+        >
+          Legacy
+        </button>
+      </div>
+
+      <div className={styles.tabContent}> {/* Define styles.tabContent */}
+        {activeTab === 'debug' && <DebugTab />}
+        {activeTab === 'legacy' && (
+          <LegacyTab
+            is_loading={props.is_loading}
+            has_content={props.has_content}
+            is_saved={props.is_saved}
+            on_save={props.on_save}
+            on_remove={props.on_remove}
+          />
+        )}
+      </div>
     </div>
-  )
-}
+  );
+};


### PR DESCRIPTION
Refactors the WebsiteActions component to display content in two tabs: "Debug" and "Legacy".

- A new `DebugTab` component is created, featuring a "ping" button that displays a confirmation message on click. This tab is active by default.
- A new `LegacyTab` component is created, which now houses all the original content and functionality of the `WebsiteActions` component.
- `WebsiteActions` has been updated to manage tab selection and rendering.
- Styles have been added for the tab navigation and presentation.
- The root elements of `DebugTab` and `LegacyTab` have been changed to React Fragments to prevent nested container styling.

This change allows for new debug functionalities to be added without cluttering the primary actions interface, which is now preserved in the "Legacy" tab.