### PR TITLE
Support building VSCode extension on windows

### DIFF
--- a/packages/vscode/webpack.config.js
+++ b/packages/vscode/webpack.config.js
@@ -147,10 +147,9 @@ const config = [
               {
                 loader: 'sass-loader',
                 options: {
-                  additionalData: `@use "${path.resolve(
-                    __dirname,
-                    '../ui/src/styles/foundation'
-                  )}" as *;`
+                  additionalData: `@use "${path
+                    .resolve(__dirname, '../ui/src/styles/foundation')
+                    .replace(/\\/g, '/')}" as *;`
                 }
               }
             ]


### PR DESCRIPTION
On Windows there is an error when trying to build the VSCode extension:

SassError: Can't find stylesheet to import.
@use "E:\Documents\repositories\CodeWebChat-Official\packages\ui\src\styles\foundation" as *;

Gemini Pro 2.5 was used to identify the root cause and resolve the issue.

Per Gemini:
Absolute Path: The build process is trying to import a SASS file using an absolute Windows path (E:\...). This is a major red flag in a portable project. Imports should almost always be relative or use configured aliases.

SASS and Backslashes: SASS, like many tools originating in the Unix world, can be particular about path separators. When it sees a quoted string with backslashes (\), it can misinterpret them as escape sequences instead of path separators. For example, \f could be interpreted as a form feed character. This mangles the path, and SASS is unable to find the file, resulting in the Can't find stylesheet to import error.