### PR TITLE
docs: refine wording and fix typos in API tools and prompting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ CWC includes battle-tested must-have API tools.
 
 ### Code Completions
 
-The best quality inline suggestions at the cost of latency. Designed to be used on demand.
+Get code at cursor position from state-of-the-art reasoning models.
 
 ✅ Includes selected context<br />
-✅ Works with any model
+✅ Designed for on-demand use
 
 ### Edit Context
 

--- a/docs/api-tools/index.mdx
+++ b/docs/api-tools/index.mdx
@@ -9,7 +9,7 @@ CWC includes battle-tested must-have API tools.
 
 ### [Code completions](./code-completions)
 
-High-quality inline suggestions designed for on-demand usage, optimized for accuracy over speed.
+Get code at cursor position from state-of-the-art reasoning models.
 
 ### [Context edit](./context-edit)
 

--- a/docs/api-tools/index.mdx
+++ b/docs/api-tools/index.mdx
@@ -9,7 +9,7 @@ CWC includes battle-tested must-have API tools.
 
 ### [Code completions](./code-completions)
 
-The best quality inline suggestions at the cost of latency. Designed to be used on demand.
+High-quality inline suggestions designed for on-demand usage, optimized for accuracy over speed.
 
 ### [Context edit](./context-edit)
 
@@ -21,4 +21,4 @@ Update files based on code blocks in truncated edit format and fix malformed dif
 
 ### [Commit messages](./commit-messages)
 
-Generate meaningful commit messages precisely adhering to your preffered style.
+Generate meaningful commit messages precisely adhering to your preferred style.

--- a/docs/chatbot-initialization.mdx
+++ b/docs/chatbot-initialization.mdx
@@ -28,8 +28,7 @@ Generated prompt depends on mode:
   <TabItem value="code completions" label="Code completions">
 
 ```
-Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing the replacement text and then proceeds with an explanation.
-Always refer to symbol "<missing_text>" as "cursor position" and "replacement" as "completion".
+Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing the replacement text and then proceeds with an explanation. Always refer to symbol "<missing_text>" as "cursor position" and "replacement" as "completion".
 <files>
   <text title="...">...</text> // selected websites
   ...

--- a/docs/chatbot-initialization.mdx
+++ b/docs/chatbot-initialization.mdx
@@ -28,7 +28,8 @@ Generated prompt depends on mode:
   <TabItem value="code completions" label="Code completions">
 
 ```
-Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing replacement text end then proceeds with explanation. Always refer to symbol "<missing_text>" as "cursor position" and "replacement" as "completion".
+Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing the replacement text and then proceeds with an explanation.
+Always refer to symbol "<missing_text>" as "cursor position" and "replacement" as "completion".
 <files>
   <text title="...">...</text> // selected websites
   ...
@@ -40,7 +41,7 @@ Find correct replacement text for the <missing text> symbol. Correctly formatted
     ...
   </file>
 </files>
-Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing replacement text end then proceeds with explanation. Always refer to symbol "<missing_text>" as "cursor position" and "replacement" as "completion".
+Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing the replacement text and then proceeds with an explanation. Always refer to symbol "<missing_text>" as "cursor position" and "replacement" as "completion".
 ```
 
   </TabItem>
@@ -48,18 +49,18 @@ Find correct replacement text for the <missing text> symbol. Correctly formatted
 
 <hr />
 
-For model's better adherence to instructions, they're palced at both ends of the prompt.<br />
+For model's better adherence to instructions, they're placed at both ends of the prompt.<br />
 [OpenAI Cookbook/Prompt Organization](https://cookbook.openai.com/examples/gpt4-1_prompting_guide#prompt-organization)
 
 :::tip Practice single-turns
 
-Chat conversations are only a construct of product interfaces, they hurt the quality of responses from the model and once your context is "poisoned" it will not recover. Whenever you're not satisfied with a reponse, **the best practice is to alawys refine your initial instructions and re-initialize a chat**.
+Chat conversations are only a construct of product interfaces, they hurt the quality of responses from the model and once your context is "poisoned" it will not recover. Whenever you're not satisfied with a response, **the best practice is to always refine your initial instructions and re-initialize a chat**.
 
 :::
 
 ## Edit formats
 
-Additional instructions are appended to your prompt in "General" mode, instructing the model to response in an appropriate format. They can be customized in your `settings.json` file.
+Additional instructions are appended to your prompt in "General" mode, instructing the model to respond in an appropriate format. They can be customized in your `settings.json` file.
 
 ### Truncated
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -677,7 +677,7 @@
           "type": "string",
           "scope": "resource",
           "description": "Instructions for code completions in chat.",
-          "default": "Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing replacement text end then proceeds with explanation. Always refer to symbol \"<missing_text>\" as \"cursor position\" and \"replacement\" as \"completion\"."
+          "default": "Find correct replacement text for the <missing text> symbol. Correctly formatted response begins with a code block containing the replacement text and then proceeds with explanation. Always refer to symbol \"<missing_text>\" as \"cursor position\" and \"replacement\" as \"completion\"."
         },
         "codeWebChat.presets": {
           "type": "array",

--- a/packages/vscode/src/view/frontend/tabs/settings/Settings.tsx
+++ b/packages/vscode/src/view/frontend/tabs/settings/Settings.tsx
@@ -80,10 +80,10 @@ export const Settings: React.FC<Props> = (props) => {
       {render_api_tool_settings({
         title: 'Code Completions',
         description:
-          'The best quality inline suggestions at the cost of latency. Designed to be used on demand.',
+          'Get code at cursor position from state-of-the-art reasoning models.',
         on_setup_click: handle_setup_code_completions_click,
         button_label: 'Setup Code Completions API Tool',
-        checkmarks: ['Includes selected context', 'Works with any model']
+        checkmarks: ['Includes selected context', 'Designed for on-demand use']
       })}
 
       {render_api_tool_settings({


### PR DESCRIPTION
- Improved clarity in code completions and commit messages descriptions (index.mdx)
- Fixed typos and refined language in prompting guide (e.g. "response" typo, phrasing tweaks)
