### PR TITLE
Handle non-ASCII characters in streamed API responses correctly

### DIFF
--- a/packages/vscode/src/utils/make-api-request.ts
+++ b/packages/vscode/src/utils/make-api-request.ts
@@ -10,7 +10,7 @@ const THINK_OPEN = '<think>'
 const THINK_CLOSE = '</think>'
 
 async function process_stream_chunk(
-  chunk: Buffer,
+  chunk: string,
   buffer: string,
   accumulated_content: string,
   last_log_time: number,
@@ -34,7 +34,7 @@ async function process_stream_chunk(
   let updated_think_block_ended = think_block_ended
 
   try {
-    updated_buffer += chunk.toString()
+    updated_buffer += chunk
     const lines = updated_buffer.split('\n')
     updated_buffer = lines.pop() || ''
 
@@ -184,8 +184,10 @@ export async function make_api_request(
       }
     )
 
+    response.data.setEncoding('utf8');
+
     return new Promise((resolve, reject) => {
-      response.data.on('data', async (chunk: Buffer) => {
+      response.data.on('data', async (chunk: string) => {
         const processing_result = await process_stream_chunk(
           chunk,
           buffer,


### PR DESCRIPTION
This pull request fixes an issue where non-ASCII characters (like Cyrillic) get corrupted when applying a chat response from a streamed API source like Gemini.

**Fixes #377**

### The Problem
When an API response is streamed, multi-byte UTF-8 characters can be split across different data chunks. The standard stream decoder was not handling these partial characters correctly, resulting in replacement characters (`�`) in the final text.

### The Solution
The solution is to explicitly set the response stream's encoding to `utf8` before processing it. This ensures that the decoder correctly handles multi-byte characters that are split across chunks.

This approach was inspired by a similar fix found in the `continuedev/continue` repository.
**Credit:** https://github.com/continuedev/continue/issues/1492

This change has been tested locally and confirms that Cyrillic characters are now preserved correctly.


### Before Fix
<img width="1869" height="402" alt="image" src="https://github.com/user-attachments/assets/c2b9211a-0f75-4011-b402-2e6e7260766b" />

### After Fix
<img width="1876" height="399" alt="image" src="https://github.com/user-attachments/assets/c9869d3b-e562-4db2-8b78-1ff6a17f122d" />