### PR TITLE
Diff views opened by cwc now get an explicit name in their "title" variable "(Working Tree)"

### DIFF
--- a/apps/editor/src/commands/apply-chat-response-command/utils/preview/vscode-ui.ts
+++ b/apps/editor/src/commands/apply-chat-response-command/utils/preview/vscode-ui.ts
@@ -32,7 +32,7 @@ export const show_diff_with_actions = async (
   const left_doc_uri = vscode.Uri.file(prepared_file.temp_file_path)
   const right_doc_uri = vscode.Uri.file(prepared_file.sanitized_path)
 
-  const title = path.basename(prepared_file.previewable_file.file_path)
+  const title = `${path.basename(prepared_file.previewable_file.file_path)} (Working Tree)`
 
   if (prepared_file.previewable_file.file_state != 'deleted') {
     await vscode.commands.executeCommand(


### PR DESCRIPTION
-this allows other extensions (e.g. fardolieri.close-tabs-via-regex) to find tabs opened by cwc, so now you can find and close cwc tabs by regex expressions.