### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/packages/shared/src/constants/chatbots.ts
+++ b/packages/shared/src/constants/chatbots.ts
@@ -52,6 +52,22 @@ export const CHATBOTS = {
       }
     }
   } as Chatbot,
+  Astraflow: {
+    url: 'https://astraflow.ucloud-global.com',
+    supports_custom_temperature: true,
+    supports_custom_top_p: true,
+    supports_system_instructions: true,
+    supports_user_provided_model: true,
+    default_system_instructions: "You're a helpful coding assistant."
+  } as Chatbot,
+  'Astraflow CN': {
+    url: 'https://astraflow.ucloud.cn',
+    supports_custom_temperature: true,
+    supports_custom_top_p: true,
+    supports_system_instructions: true,
+    supports_user_provided_model: true,
+    default_system_instructions: "You're a helpful coding assistant."
+  } as Chatbot,
   Arena: {
     url: 'https://arena.ai/',
     supports_user_provided_model: true


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) by UCloud as a supported chatbot in CodeWebChat — both the global and China endpoints.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.

### Changes

- **`packages/shared/src/constants/chatbots.ts`**: Registers two new chatbot entries in the `CHATBOTS` constant, inserted in alphabetical order before `Arena`:
  - **`Astraflow`** — global endpoint at `https://astraflow.ucloud-global.com`
  - **`Astraflow CN`** — China endpoint at `https://astraflow.ucloud.cn`

Both entries follow the same pattern as `OpenRouter` (another OpenAI-compatible aggregation platform with a web chat UI), enabling:
- Custom temperature
- Custom top-p
- System instructions
- User-provided model selection
- Default system instructions pre-filled

### References
- Global: https://astraflow.ucloud-global.com
- China: https://astraflow.ucloud.cn
- API key signup (global): https://astraflow.ucloud-global.com
- API key signup (China): https://astraflow.ucloud.cn